### PR TITLE
Remove validations from dropdown

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -35,8 +35,6 @@ body:
         - Chrome
         - Safari
         - Microsoft Edge
-      validations:
-        required: true
 
   - type: textarea
     id: steps


### PR DESCRIPTION
## Summary

Quick fix for bug reports since you can't require a dropdown item to be selected.