### PR TITLE
Added expansion query param support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ Home page:
 Review page:
 ![Review page](https://github.com/mateuscechetto/hearthstone-set-review-bot/assets/32515099/c942527c-7b76-4601-add4-fe41ece9299b)
 
-
 ## Technologies
 
 ### Backend
@@ -19,7 +18,6 @@ Review page:
 - OAuth2 (passport)
 - JWT
 - MongoDB (mongoose)
-
 
 ### Frontend
 
@@ -82,7 +80,7 @@ The backend will be served at http://localhost:5000
 In another terminal run the frontend:
 
     cd client
-    ng serve
+    npm start
 
 The frontend will be served at http://localhost:4200
 

--- a/client/jest.config.js
+++ b/client/jest.config.js
@@ -1,0 +1,29 @@
+const { pathsToModuleNameMapper } = require('ts-jest');
+const { compilerOptions } = require('./tsconfig.json');
+
+const config = {
+    preset: 'jest-preset-angular',
+    testEnvironment: 'jsdom',
+    moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths),
+    modulePaths: ['<rootDir>'],
+    coverageDirectory: '../coverage',
+    moduleFileExtensions: ['js', 'json', 'ts'],
+    testRegex: '.*\\.spec\\.ts$',
+    transform: { '^.+\\.(t|j)s$': 'jest-preset-angular' },
+    collectCoverageFrom: ['**/*.(t|j)s'],
+    setupFilesAfterEnv: [
+      "<rootDir>/src/setup.jest.ts"
+    ],
+    testPathIgnorePatterns: [
+      "<rootDir>/node_modules/",
+      "<rootDir>/dist/"
+    ],
+    globals: {
+      "ts-jest": {
+          tsConfig: "<rootDir>/tsconfig.spec.json",
+          stringifyContentPathRegex: "\\.html$"
+      }
+    },
+};
+
+module.exports = config;

--- a/client/package.json
+++ b/client/package.json
@@ -46,21 +46,5 @@
     "@typescript-eslint/parser": "5.62.0",
     "eslint": "^8.51.0",
     "typescript": "~5.0.2"
-  },
-  "jest": {
-    "preset": "jest-preset-angular",
-    "setupFilesAfterEnv": [
-      "<rootDir>/src/setup.jest.ts"
-    ],
-    "testPathIgnorePatterns": [
-      "<rootDir>/node_modules/",
-      "<rootDir>/dist/"
-    ],
-    "globals": {
-      "ts-jest": {
-        "tsConfig": "<rootDir>/tsconfig.spec.json",
-        "stringifyContentPathRegex": "\\.html$"
-      }
-    }
   }
 }

--- a/client/src/app/app.component.spec.ts
+++ b/client/src/app/app.component.spec.ts
@@ -1,10 +1,11 @@
 import { TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { AppComponent } from './app.component';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 describe('AppComponent', () => {
   beforeEach(() => TestBed.configureTestingModule({
-    imports: [RouterTestingModule],
+    imports: [HttpClientTestingModule, RouterTestingModule],
   }));
 
   it('should create the app', () => {

--- a/client/src/app/card-view/data-access/card/card.service.spec.ts
+++ b/client/src/app/card-view/data-access/card/card.service.spec.ts
@@ -2,13 +2,14 @@ import { TestBed } from '@angular/core/testing';
 
 import { CardService } from './card.service';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { RouterTestingModule } from '@angular/router/testing';
 
 describe('CardService', () => {
   let service: CardService;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule]
+      imports: [HttpClientTestingModule, RouterTestingModule]
     });
     service = TestBed.inject(CardService);
   });

--- a/client/src/app/card-view/feature/card-view/card-view.page.html
+++ b/client/src/app/card-view/feature/card-view/card-view.page.html
@@ -16,11 +16,11 @@
       *ngIf="isInPreExpansionSeason && context.activeExpansion == CURRENT_EXPANSION; else notPreExpansionSeason"
     >
       <p-button
-        *ngIf="loggedUser && !loggedUser.isStreamer && pageUser?.name == loggedUser.name; else notStreamer"
+        *ngIf="loggedUser && !loggedUser.isStreamer && pageUser?.name == loggedUser.name; else hideChatRatings"
         class="col-6 col-offset-6 flex-order-1 md:flex-order-1 md:col-2 md:col-offset-0 mt-4"
         data-testid="record-chat-ratings-button"
         label="Record chat ratings"
-        (onClick)="onUserIsStreamer()"
+        (onClick)="onShowChatRatings()"
       ></p-button>
     </ng-container>
     <ng-template #notPreExpansionSeason>
@@ -32,14 +32,14 @@
         ratings.
       </b>
     </ng-template>
-    <ng-template #notStreamer>
+    <ng-template #hideChatRatings>
       <p-button
         *ngIf="loggedUser && loggedUser.name == pageUser?.name"
         class="col-6 flex-order-0 md:flex-order-0 md:col-2 mt-4"
         styleClass="p-button-danger"
         data-testid="hide-chat-ratings-button"
         label="Hide chat ratings"
-        (onClick)="onUserIsNOTStreamer()"
+        (onClick)="onHideChatRatings()"
       ></p-button>
     </ng-template>
   </div>

--- a/client/src/app/card-view/feature/card-view/card-view.page.spec.ts
+++ b/client/src/app/card-view/feature/card-view/card-view.page.spec.ts
@@ -9,30 +9,44 @@ import { CardService } from '../../data-access/card/card.service';
 import { UserService } from '../../../shared/data-access/user/user.service';
 import { RatingService } from '../../data-access/rating/rating.service';
 import { EnvironmentService } from '../../../shared/environment/environment.service';
-
+import { CURRENT_EXPANSION, ExpansionService } from '@app/shared/data-access/expansion/expansion.service';
 
 const serviceMock = {
   getCards: jest.fn(() => of(cardsMock.map(card => ({ ...card, rating: 2 })))),
+  loading: {
+    pipe: jest.fn(() => of(false))
+  }
 }
 
 const userServiceMock = {
   getUserByUsername: jest.fn((username) => of({ name: 'molino_hs', image: '', isStreamer: true })),
   getUser: jest.fn(() => of({ name: 'molino_hs', image: '', isStreamer: true })),
   userIsStreamer: jest.fn(() => of(true)),
+  loggedUser: {
+    name: 'molino_hs',
+    image: '',
+    isStreamer: true,
+    subscribe: jest.fn()
+  },
 }
 
 const ratingServiceMock = {}
 
 const activatedRouteMock = {
-  snapshot: {
-    params: { username: of('molino_hs') }
+  params: { 
+    username: of('molino_hs'),
+    pipe: jest.fn(() => of('molino_hs'))
   },
+  queryParams: of({ expansion: 'mock_expansion' })
 }
 
 const environmentServiceMock = {
   isInPreExpansionSeason: jest.fn(() => true),
 }
 
+const expansionServiceMock = {
+  activeExpansion: of(CURRENT_EXPANSION),
+}
 
 describe('CardViewComponent', () => {
   let component: CardViewPage;
@@ -45,7 +59,8 @@ describe('CardViewComponent', () => {
         { provide: CardService, useValue: serviceMock },
         { provide: UserService, useValue: userServiceMock },
         { provide: RatingService, useValue: ratingServiceMock },
-        { provide: EnvironmentService, useValue: environmentServiceMock}
+        { provide: EnvironmentService, useValue: environmentServiceMock },
+        { provide: ExpansionService, useValue: expansionServiceMock }
       ]
     });
     fixture = TestBed.createComponent(CardViewPage);
@@ -69,17 +84,15 @@ describe('CardViewComponent', () => {
     );
 
     expect(recordChatButton).toBeFalsy();
-    
     expect(hideChatButton).toBeTruthy();
-
     expect(message).toBeFalsy();
-
   });
 
   it('should show record chat ratings button when it is pre-expansion season and user is NOT a streamer', () => {
     jest.spyOn(userServiceMock, 'getUser').mockReturnValueOnce(of({ name: 'molino_hs', image: '', isStreamer: false }));
     fixture = TestBed.createComponent(CardViewPage);
     fixture.detectChanges();
+
     const recordChatButton = fixture.debugElement.query(
       By.css('[data-testid="record-chat-ratings-button"]')
     );
@@ -91,16 +104,15 @@ describe('CardViewComponent', () => {
     );
 
     expect(recordChatButton).toBeTruthy();
-    
     expect(hideChatButton).toBeFalsy();
     expect(message).toBeFalsy();
-
   });
 
   it('should NOT show record chat ratings button when it is not pre-expansion season', () => {
     jest.spyOn(environmentServiceMock, 'isInPreExpansionSeason').mockReturnValueOnce(false);
     fixture = TestBed.createComponent(CardViewPage);
     fixture.detectChanges();
+
     const recordChatButton = fixture.debugElement.query(
       By.css('[data-testid="record-chat-ratings-button"]')
     );
@@ -113,9 +125,7 @@ describe('CardViewComponent', () => {
 
     expect(recordChatButton).toBeFalsy();
     expect(hideChatButton).toBeFalsy();
-
     expect(message).toBeTruthy();
-
   });
 
 });

--- a/client/src/app/card-view/feature/card-view/card-view.page.spec.ts
+++ b/client/src/app/card-view/feature/card-view/card-view.page.spec.ts
@@ -22,21 +22,13 @@ const userServiceMock = {
   getUserByUsername: jest.fn((username) => of({ name: 'molino_hs', image: '', isStreamer: true })),
   getUser: jest.fn(() => of({ name: 'molino_hs', image: '', isStreamer: true })),
   userIsStreamer: jest.fn(() => of(true)),
-  loggedUser: {
-    name: 'molino_hs',
-    image: '',
-    isStreamer: true,
-    subscribe: jest.fn()
-  },
+  loggedUser: of({ name: 'molino_hs', image: '',  isStreamer: true }),
 }
 
 const ratingServiceMock = {}
 
 const activatedRouteMock = {
-  params: { 
-    username: of('molino_hs'),
-    pipe: jest.fn(() => of('molino_hs'))
-  },
+  params: of({ username: 'molino_hs'}),
   queryParams: of({ expansion: 'mock_expansion' })
 }
 
@@ -63,6 +55,7 @@ describe('CardViewComponent', () => {
         { provide: ExpansionService, useValue: expansionServiceMock }
       ]
     });
+    userServiceMock.loggedUser = of({ name: 'molino_hs', image: '', isStreamer: true });
     fixture = TestBed.createComponent(CardViewPage);
     component = fixture.componentInstance;
     fixture.detectChanges();
@@ -89,7 +82,7 @@ describe('CardViewComponent', () => {
   });
 
   it('should show record chat ratings button when it is pre-expansion season and user is NOT a streamer', () => {
-    jest.spyOn(userServiceMock, 'getUser').mockReturnValueOnce(of({ name: 'molino_hs', image: '', isStreamer: false }));
+    userServiceMock.loggedUser = of({ name: 'molino_hs', image: '', isStreamer: false });
     fixture = TestBed.createComponent(CardViewPage);
     fixture.detectChanges();
 

--- a/client/src/app/card-view/feature/card-view/card-view.page.ts
+++ b/client/src/app/card-view/feature/card-view/card-view.page.ts
@@ -147,7 +147,7 @@ export class CardViewPage {
       });
   }
 
-  onUserIsStreamer(): void {
+  onShowChatRatings(): void {
     if (this.loggedUser) {
       this.userService.userIsStreamer(this.loggedUser.name).subscribe({
         next: (loggedUser) => {
@@ -162,7 +162,7 @@ export class CardViewPage {
     }
   }
 
-  onUserIsNOTStreamer(): void {
+  onHideChatRatings(): void {
     if (this.loggedUser) {
       this.userService.userIsNOTStreamer(this.loggedUser.name).subscribe({
         next: (loggedUser) => {

--- a/client/src/app/card-view/ui/card-grid-skeleton/card-grid-skeleton.component.spec.ts
+++ b/client/src/app/card-view/ui/card-grid-skeleton/card-grid-skeleton.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { CardGridSkeletonComponent } from './card-grid-skeleton.component';
+import { RouterTestingModule } from '@angular/router/testing';
 
 describe('CardGridSkeletonComponent', () => {
   let component: CardGridSkeletonComponent;
@@ -8,7 +9,7 @@ describe('CardGridSkeletonComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [CardGridSkeletonComponent]
+      imports: [CardGridSkeletonComponent, RouterTestingModule]
     });
     fixture = TestBed.createComponent(CardGridSkeletonComponent);
     component = fixture.componentInstance;

--- a/client/src/app/card-view/ui/record-chat/record-chat.component.spec.ts
+++ b/client/src/app/card-view/ui/record-chat/record-chat.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { RecordChatComponent } from './record-chat.component';
+import { RouterTestingModule } from '@angular/router/testing';
 
 describe('RecordChatComponent', () => {
   let component: RecordChatComponent;
@@ -8,6 +9,7 @@ describe('RecordChatComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
+      imports: [RouterTestingModule]
     });
     fixture = TestBed.createComponent(RecordChatComponent);
     component = fixture.componentInstance;

--- a/client/src/app/home/data-access/home.service.spec.ts
+++ b/client/src/app/home/data-access/home.service.spec.ts
@@ -2,13 +2,14 @@ import { TestBed } from '@angular/core/testing';
 
 import { HomeService } from './home.service';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { RouterTestingModule } from '@angular/router/testing';
 
 describe('CardService', () => {
   let service: HomeService;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule]
+      imports: [HttpClientTestingModule, RouterTestingModule]
     });
     service = TestBed.inject(HomeService);
   });

--- a/client/src/app/home/feature/home/home.page.spec.ts
+++ b/client/src/app/home/feature/home/home.page.spec.ts
@@ -4,12 +4,14 @@ import { HomePage } from './home.page';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { of } from 'rxjs';
 import { ActivatedRoute } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
 
 
 const activatedRouteMock = {
   snapshot: {
     params: { username: of('molino_hs') }
   },
+  queryParams: of({ expansion: 'mock_expansion' })
 }
 
 describe('HomePage', () => {
@@ -18,7 +20,7 @@ describe('HomePage', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule],
+      imports: [HttpClientTestingModule, RouterTestingModule],
       providers: [
         { provide: ActivatedRoute, useValue: activatedRouteMock },
       ]

--- a/client/src/app/layout/header/header.component.html
+++ b/client/src/app/layout/header/header.component.html
@@ -1,6 +1,6 @@
 <header class="grid p-2 sticky top-0 z-5 bg-white" style="border-bottom: 1px solid #ccc;">
   <div class="col-2 md:col-4">
-    <a routerLink="/">
+    <a routerLink="/" queryParamsHandling="merge">
       <img
         src="../../../assets/images/logo badlands.png"
         width="36px"

--- a/client/src/app/layout/header/header.component.spec.ts
+++ b/client/src/app/layout/header/header.component.spec.ts
@@ -1,6 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { HeaderComponent } from './header.component';
+import { RouterTestingModule } from '@angular/router/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 describe('HeaderComponent', () => {
   let component: HeaderComponent;
@@ -8,7 +10,7 @@ describe('HeaderComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HeaderComponent]
+      imports: [HttpClientTestingModule, HeaderComponent, RouterTestingModule]
     });
     fixture = TestBed.createComponent(HeaderComponent);
     component = fixture.componentInstance;

--- a/client/src/app/layout/header/header.component.ts
+++ b/client/src/app/layout/header/header.component.ts
@@ -54,11 +54,11 @@ export class HeaderComponent {
   }
 
   selectUser(streamer: string) {
-    this.router.navigate(['review', streamer]);
+    this.router.navigate(['review', streamer], { queryParamsHandling: 'merge' });
   }
 
   changeExpansion(event: DropdownChangeEvent) {
-    this.expansionService.changeActiveExpansion$.next(event.value);
+    this.expansionService.setActiveExpansion(event.value);
   }
 
   login() {

--- a/client/src/app/not-found/feature/not-found/not-found.page.html
+++ b/client/src/app/not-found/feature/not-found/not-found.page.html
@@ -1,1 +1,1 @@
-<p>Review not found. <a [routerLink]="['/home']">Go back home to see who have reviewed.</a></p>
+<p>Review not found. <a [routerLink]="['/home']" queryParamsHandling="merge">Go back home to see who have reviewed.</a></p>

--- a/client/src/app/shared/data-access/expansion/expansion.service.spec.ts
+++ b/client/src/app/shared/data-access/expansion/expansion.service.spec.ts
@@ -2,13 +2,14 @@ import { TestBed } from '@angular/core/testing';
 
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ExpansionService } from './expansion.service';
+import { RouterTestingModule } from '@angular/router/testing';
 
 describe('ExpansionService', () => {
   let service: ExpansionService;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule]
+      imports: [HttpClientTestingModule, RouterTestingModule]
     });
     service = TestBed.inject(ExpansionService);
   });

--- a/client/src/app/shared/data-access/expansion/expansion.service.ts
+++ b/client/src/app/shared/data-access/expansion/expansion.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
-import { BehaviorSubject, Observable, Subject } from 'rxjs';
+import { ActivatedRoute, Router } from '@angular/router';
+import { BehaviorSubject, Observable, filter } from 'rxjs';
 
 export const CURRENT_EXPANSION = 'Whizbang\'s Workshop';
 
@@ -15,17 +16,27 @@ export class ExpansionService {
   );
 
   // selectors
-  activeExpansion: Observable<string> = this.state;
+  activeExpansion: Observable<string> = this.state.asObservable();
 
-  // sources
-  changeActiveExpansion$ = new Subject<string>();
-
-  constructor() {
+  constructor(private route: ActivatedRoute, private router: Router) {
     // reducers
-    this.changeActiveExpansion$.subscribe({
-      next: (expansion) => {
-        this.state.next(expansion);
-      },
+    this.route.queryParams.pipe(
+      filter(params => params['expansion'])
+    ).subscribe(params => {
+      this.state.next(params['expansion']);
+    });
+  }
+
+  setActiveExpansion(expansion: string) {
+    this.state.next(expansion);
+    this.updateQueryParam();
+  }
+
+  private updateQueryParam() {
+    this.router.navigate([], {
+      relativeTo: this.route,
+      queryParams: { expansion: this.state.value },
+      queryParamsHandling: 'merge'
     });
   }
 }

--- a/client/src/app/shared/data-access/user/user.service.spec.ts
+++ b/client/src/app/shared/data-access/user/user.service.spec.ts
@@ -2,13 +2,14 @@ import { TestBed } from '@angular/core/testing';
 
 import { UserService } from './user.service';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { RouterTestingModule } from '@angular/router/testing';
 
 describe('UserService', () => {
   let service: UserService;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule]
+      imports: [HttpClientTestingModule, RouterTestingModule]
     });
     service = TestBed.inject(UserService);
   });

--- a/client/src/app/shared/guards/user.guard.spec.ts
+++ b/client/src/app/shared/guards/user.guard.spec.ts
@@ -2,13 +2,16 @@ import { TestBed } from '@angular/core/testing';
 import { CanActivateFn } from '@angular/router';
 
 import { userGuard } from './user.guard';
+import { RouterTestingModule } from '@angular/router/testing';
 
 describe('userGuard', () => {
   const executeGuard: CanActivateFn = (...guardParameters) => 
       TestBed.runInInjectionContext(() => userGuard(...guardParameters));
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule],
+    });
   });
 
   it('should be created', () => {

--- a/client/src/app/shared/guards/user.guard.ts
+++ b/client/src/app/shared/guards/user.guard.ts
@@ -12,7 +12,7 @@ export const userGuard: CanActivateFn = (route, state) => {
       if (hasUser) {
         return true;
       } else {
-        router.navigate(['/not-found']);
+        router.navigate(['/not-found'], { queryParamsHandling: 'merge' });
         return false;
       }
     })
@@ -31,12 +31,12 @@ export const loginGuard: CanActivateFn = (route, state) => {
       ) {
         return true;
       } else {
-        router.navigate(['/review', route.params['username'], 'view-only']);
+        router.navigate(['/review', route.params['username'], 'view-only'], { queryParamsHandling: 'merge' });
         return false;
       }
     }),
     catchError(() => {
-      router.navigate(['/review', route.params['username'], 'view-only']);
+      router.navigate(['/review', route.params['username'], 'view-only'], { queryParamsHandling: 'merge' });
       return of(false);
     })
   );
@@ -47,7 +47,7 @@ export const redirectGuard: CanActivateFn = (route, state) => {
   const router = inject(Router);
   return service.getUser().pipe(
     map((user) => {
-      router.navigate(['/review', user.name.toLowerCase()]);
+      router.navigate(['/review', user.name.toLowerCase()], { queryParamsHandling: 'merge' });
       return false;
     })
   );

--- a/client/src/app/stats/data-access/stats.service.spec.ts
+++ b/client/src/app/stats/data-access/stats.service.spec.ts
@@ -2,13 +2,14 @@ import { TestBed } from '@angular/core/testing';
 
 import { StatsService } from './stats.service';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { RouterTestingModule } from '@angular/router/testing';
 
 describe('CardService', () => {
   let service: StatsService;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule]
+      imports: [HttpClientTestingModule, RouterTestingModule]
     });
     service = TestBed.inject(StatsService);
   });

--- a/client/src/app/stats/feature/stats.page.spec.ts
+++ b/client/src/app/stats/feature/stats.page.spec.ts
@@ -15,6 +15,12 @@ const userServiceMock = {
 const statsServiceMock = {
   getCards: jest.fn(() => of([])),
   getAverageRatingsByClass: jest.fn(() => of([])),
+  loadingCards: {
+    pipe: jest.fn(() => of(true))
+  },
+  loadingAvgRatingByClass: {
+    pipe: jest.fn(() => of(true))
+  }
 }
 
 const activatedRouteMock = {
@@ -22,8 +28,6 @@ const activatedRouteMock = {
     params: { username: of('molino_hs') }
   },
 }
-
-
 
 describe('StatsPage', () => {
   let component: StatsPage;
@@ -33,8 +37,8 @@ describe('StatsPage', () => {
     TestBed.configureTestingModule({
       providers:[
         { provide: ActivatedRoute, useValue: activatedRouteMock },
-        {provide: UserService, useValue: userServiceMock },
-        {provide: StatsService, useValue: statsServiceMock },
+        { provide: UserService, useValue: userServiceMock },
+        { provide: StatsService, useValue: statsServiceMock },
       ]
     });
     fixture = TestBed.createComponent(StatsPage);

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
   "compileOnSave": false,
   "compilerOptions": {


### PR DESCRIPTION
## Summary

This adds the expansion into the query parameter for the route so it appears as part of the URL and allows the user's journey through the website to be a consistent experience; now when you navigate to a streamer's reviews, refresh the page, etc. it'll stay on the same expansion you have selected.

## Screenshots/Video

https://github.com/mateuscechetto/hearthstone-set-review-bot/assets/10130985/26d04bd8-a8ca-496a-a0fc-f8a3b2e18331

## Testing

Validate that the expansion is preserved in all navigation cases and that there aren't any side effects from the interaction between the service value and the query parameter.

## Checklist

#### Basics

- [x] Does `npm run build` succeed?
- [x] Does `npm run test` succeed? (More than before)

#### Testing

- [x] Did you create new tests and/or update existing tests?
- [x] Did you validate that your changes work hosted locally?

#### Accessibility (UX)

N/A