### PR TITLE
Make user names case sensitive

### DIFF
--- a/client/src/app/shared/guards/user.guard.ts
+++ b/client/src/app/shared/guards/user.guard.ts
@@ -47,7 +47,7 @@ export const redirectGuard: CanActivateFn = (route, state) => {
   const router = inject(Router);
   return service.getUser().pipe(
     map((user) => {
-      router.navigate(['/review', user.name.toLowerCase()], { queryParamsHandling: 'merge' });
+      router.navigate(['/review', user.name], { queryParamsHandling: 'merge' });
       return false;
     })
   );

--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -164,16 +164,14 @@ router.get('/logout', (req, res) => {
 });
 
 router.get('/hasUser', async (req, res) => {
-    const regex = new RegExp(["^", req.query.username.toLowerCase(), "$"].join(""), "i");
-    const hasUser = !!await User.exists({ name: regex });
+    const hasUser = !!await User.exists({ name: req.query.username });
     res.status(status.OK).send(
         hasUser
     );
 });
 
 router.get('/user', async (req, res) => {
-    const regex = new RegExp(["^", req.query.username.toLowerCase(), "$"].join(""), "i");
-    const user = await User.findOne({ name: regex });
+    const user = await User.findOne({ name: req.query.username });
     res.status(status.OK).send(
         user
     );


### PR DESCRIPTION
Resolves #39 

## Summary

This PR complements #42 with the goal of solving #39. Now 2 different instances of users appear in the database, and when the user logs in on the application, it uses the capitalized name (twitch display_name), but in some places of the application we were lowercasing it, what makes the app wrongly get the other user.
<!-- Please provide an overview of the work that was completed and the changes this PR introduces. Use the sections below as a guide to provide additional information. -->

