### PR TITLE
Added search function to All Cards on stats page

### DIFF
--- a/client/src/app/layout/header/header.component.html
+++ b/client/src/app/layout/header/header.component.html
@@ -11,10 +11,9 @@
   </div>
   <div class="col-12 flex-order-1 md:col-4 md:flex-order-0" *ngIf="options | async as users">
     <p-autoComplete
-      [(ngModel)]="userSearchValue"
       [suggestions]="suggestions"
       [showClear]="true"
-      placeholder="Find a Review"
+      placeholder="Find a Reviewer"
       [style]="{ width: '100%' }"
       [inputStyle]="{ width: '100%' }"
       (completeMethod)="searchUser($event, users)"

--- a/client/src/app/layout/header/header.component.ts
+++ b/client/src/app/layout/header/header.component.ts
@@ -41,7 +41,6 @@ export class HeaderComponent {
 
   loggedUser = this.userService.loggedUser;
 
-  userSearchValue: any;
   options = this.userService.users.pipe();
   suggestions: string[] = [];
 

--- a/client/src/app/stats/feature/stats.page.html
+++ b/client/src/app/stats/feature/stats.page.html
@@ -62,8 +62,18 @@
     </p-table>
   </div>
   <div class="col-12 lg:col-10 lg:col-offset-1 flex-order-1">
-    <p-table [value]="hotCards" [rows]="10" [paginator]="true">
-      <ng-template pTemplate="caption">All Cards </ng-template>
+    <p-table [value]="filteredHotCards" [rows]="10" [paginator]="true">
+      <ng-template pTemplate="caption">
+        <div class="allCardsHeader">
+          All Cards
+          <input
+            placeholder="Find a Card"
+            [style]="{ width: '80%' }"
+            (input)="filterHotCards($event)"
+            class="searchInput"
+          />
+        </div>
+      </ng-template>
       <ng-template pTemplate="header">
         <tr>
           <th pSortableColumn="hsClass" style="width: 16.6%">
@@ -73,7 +83,7 @@
             Name <p-sortIcon field="name"></p-sortIcon>
           </th>
           <th
-            *ngIf="hotCards[0]?.hsr_rating"
+            *ngIf="filteredHotCards[0]?.hsr_rating"
             pSortableColumn="hsr_rating"
             style="width: 16.6%"
             pTooltip="Rating calculated using HSReplay data from the the first patch after expansion"
@@ -120,7 +130,7 @@
           >
             <td>{{card.hsClass}}</td>
             <td>{{card.name}}</td>
-            <td *ngIf="hotCards[0]?.hsr_rating">{{ card.hsr_rating }}</td>
+            <td *ngIf="filteredHotCards[0]?.hsr_rating">{{ card.hsr_rating }}</td>
             <td>{{card.avgRating | number: '1.0-2' }}</td>
             <td>± {{(card.standardDeviation | number: '1.0-2') || 0  }}</td>
             <td>{{card.ratings.length}}</td>

--- a/client/src/app/stats/feature/stats.page.scss
+++ b/client/src/app/stats/feature/stats.page.scss
@@ -1,3 +1,22 @@
+.searchInput {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+    box-sizing: border-box;
+    font-size: 1rem;
+    color: #495057;
+    background: #ffffff;
+    padding: 0.75rem 0.75rem;
+    border: 1px solid #ced4da;
+    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
+    appearance: none;
+    border-radius: 6px;
+}
+
+.allCardsHeader {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
 .listItem {
     border: solid #dee2e6;
     border-width: 0 0 1px 0;

--- a/client/src/app/stats/feature/stats.page.ts
+++ b/client/src/app/stats/feature/stats.page.ts
@@ -25,6 +25,7 @@ import {
   BEST_CLASSES_MOCK,
 } from '@stats/feature/stats-data.mock';
 import { SkeletonModule } from 'primeng/skeleton';
+import { InputTextModule } from 'primeng/inputtext';
 
 @Component({
   selector: 'app-Stats',
@@ -45,19 +46,21 @@ import { SkeletonModule } from 'primeng/skeleton';
     AsyncPipe,
     SkeletonModule,
     NgTemplateOutlet,
+    InputTextModule
   ],
   standalone: true,
 })
 export class StatsPage {
   title = 'Showdown in the Badlands Card Review';
   hotCards: HotCards[] = [];
+  filteredHotCards: HotCards[] = [];
   ratingsByClass: AverageRatingByClass[] = [];
   cardsByClass: { [key: string]: HotCards[] } = {};
 
   loadingCards = this.statsService.loadingCards.pipe(
     tap((loading) => {
       if (loading) {
-        this.hotCards = ALL_CARDS_TABLE_MOCK;
+        this.filteredHotCards = ALL_CARDS_TABLE_MOCK;
       }
     })
   );
@@ -75,6 +78,7 @@ export class StatsPage {
     this.statsService.getCards().subscribe({
       next: (cards) => {
         this.hotCards = cards;
+        this.filteredHotCards = cards;
         this.setClassesCards(cards);
       },
     });
@@ -84,6 +88,15 @@ export class StatsPage {
         this.ratingsByClass = ratingsByClass;
       },
     });
+  }
+
+  filterHotCards(event: Event) {
+    const searchQuery = (event.target as HTMLInputElement).value.toLowerCase();
+    if (searchQuery === '') {
+      this.filteredHotCards = this.hotCards;
+    } else {
+      this.filteredHotCards = this.hotCards.filter(card => card.name.toLowerCase().includes(searchQuery));
+    }
   }
 
   setClassesCards(cards: HotCards[]) {


### PR DESCRIPTION
## Summary

This PR adds the first instance of card searching to the HS Set Review system, specifically to the All Cards table on the stats page. In the future, this could be expanded to other tables (notably the class tables on the stats page) or made part of the home screen/header when card pages exist.

## Screenshots/Video

https://github.com/mateuscechetto/hearthstone-set-review-bot/assets/10130985/bbb335f5-3e7d-4e84-a019-ec3df46ee1e0

## Testing

- Run the client and go to the stats page
- Search for your favorite card in the All Cards table
- Sort by column as desired and make sure the results are valid

## Checklist

#### Basics

- [x] Does `npm run build` succeed?
- [x] Does `npm run test` succeed?

#### Testing

- [x] Did you create new tests and/or update existing tests?
- [x] Did you validate that your changes work hosted locally?

#### Accessibility (UX)

N/A