### PR TITLE
Make it possible to view multiple reviews at same time

### DIFF
--- a/client/src/app/card-view/data-access/card/card.service.ts
+++ b/client/src/app/card-view/data-access/card/card.service.ts
@@ -60,15 +60,19 @@ export class CardService {
   }
 
   getCompareReviewersCards(
-    reviewers: string[]
+    reviewers: string[] | string
   ): Observable<CompareCardAPIReturn[][]> {
     if (!reviewers || reviewers.length === 0) {
       return of([]);
     }
+    if (typeof reviewers === 'string') {
+      return combineLatest([this.getCompareReviewer(reviewers, true)]);
+    }
+
     const requests = reviewers.map((reviewer) =>
       this.getCompareReviewer(reviewer, true)
     );
-    return combineLatest(requests) as Observable<CompareCardAPIReturn[][]>;
+    return combineLatest(requests);
   }
 
   private getCompareReviewer(

--- a/client/src/app/card-view/data-access/card/card.service.ts
+++ b/client/src/app/card-view/data-access/card/card.service.ts
@@ -1,7 +1,18 @@
 import { environment } from '@environment/environment';
 import { Injectable } from '@angular/core';
-import { RatedCardAPIReturn } from '@shared/models/hs-card';
-import { BehaviorSubject, Observable, map, switchMap, tap } from 'rxjs';
+import {
+  CompareCardAPIReturn,
+  RatedCardAPIReturn,
+} from '@shared/models/hs-card';
+import {
+  BehaviorSubject,
+  Observable,
+  combineLatest,
+  map,
+  of,
+  switchMap,
+  tap,
+} from 'rxjs';
 import { HttpClient } from '@angular/common/http';
 import { ExpansionService } from '@shared/data-access/expansion/expansion.service';
 
@@ -21,6 +32,8 @@ export class CardService {
 
   // selectors
   loading = this.loadingState.pipe(map((v) => v.loading));
+
+  private cardsCache: { [key: string]: CompareCardAPIReturn[] } = {};
 
   constructor(
     private http: HttpClient,
@@ -43,6 +56,43 @@ export class CardService {
         )
       ),
       tap(() => this.loadingState.next({ loading: false }))
+    );
+  }
+
+  getCompareReviewersCards(
+    reviewers: string[]
+  ): Observable<CompareCardAPIReturn[][]> {
+    if (!reviewers || reviewers.length === 0) {
+      return of([]);
+    }
+    const requests = reviewers.map((reviewer) =>
+      this.getCompareReviewer(reviewer, true)
+    );
+    return combineLatest(requests) as Observable<CompareCardAPIReturn[][]>;
+  }
+
+  private getCompareReviewer(
+    userName: string,
+    useCachedValue: boolean = false
+  ): Observable<CompareCardAPIReturn[]> {
+    if (useCachedValue && this.cardsCache[userName]) {
+      return of(this.cardsCache[userName]);
+    }
+
+    return this.expansionService.activeExpansion.pipe(
+      switchMap((expansion) =>
+        this.http.get<CompareCardAPIReturn[]>(
+          `${environment.apiUrl}/api/compareRatings`,
+          {
+            withCredentials: true,
+            params: {
+              userName,
+              expansion,
+            },
+          }
+        )
+      ),
+      tap((cards) => (this.cardsCache[userName] = cards))
     );
   }
 }

--- a/client/src/app/card-view/feature/card-view/card-view.page.html
+++ b/client/src/app/card-view/feature/card-view/card-view.page.html
@@ -44,38 +44,59 @@
     </ng-template>
   </div>
 
-  <p-dataView #dv [value]="cards" [layout]="layout">
-    <ng-template let-card pTemplate="gridItem">
-      <app-card-grid-item
-        [showSkeleton]="!!(loadingCards$ | async)"
-        [card]="card"
+  <div *ngIf="options | async as users">
+    <form [formGroup]="compareReviewsForm" class="flex align-items-center ml-2 md:ml-7 gap-2">
+      <label for="CompareReviews">Compare reviews:</label>
+      <p-autoComplete
+        id="CompareReviews"
+        [suggestions]="suggestions"
+        [showClear]="true"
+        placeholder="Find a Reviewer"
+        [multiple]="true"
+        formControlName="reviewers"
+        (completeMethod)="searchUser($event, users)"
+      ></p-autoComplete>
+    </form>
+  </div>
+
+  <ng-container
+    *ngIf="{reviewers: (reviewersToCompare$ | async) || []} as reviewersContext"
+  >
+    <p-dataView #dv [value]="cards" [layout]="layout">
+      <ng-template let-card pTemplate="gridItem">
+        <app-card-grid-item
+          [showSkeleton]="!!(loadingCards$ | async)"
+          [card]="card"
+          [userImg]="pageUser?.image ?? ''"
+          [isLoggedUser]="pageUser?.name == loggedUser?.name"
+          [isUserStreamer]="!!pageUser?.isStreamer"
+          [streamerView]="!!loggedUser && loggedUser.isStreamer && pageUser?.name == loggedUser.name"
+          [isInPreExpansionSeason]="isInPreExpansionSeason && context.activeExpansion == CURRENT_EXPANSION"
+          [reviewersToCompare]="reviewersContext.reviewers"
+          (imageClick)="showModal($event)"
+          (changedRate)="onChangedRate($event)"
+          (recordChat)="onRecordChat($event)"
+          (stopRecording)="onStopRecording($event)"
+        ></app-card-grid-item>
+      </ng-template>
+    </p-dataView>
+
+    <div *ngIf="shouldShowModal && modalCard">
+      <app-card-view-modal
+        [card]="modalCard"
+        [(shouldShowModal)]="shouldShowModal"
         [userImg]="pageUser?.image ?? ''"
         [isLoggedUser]="pageUser?.name == loggedUser?.name"
         [isUserStreamer]="!!pageUser?.isStreamer"
         [streamerView]="!!loggedUser && loggedUser.isStreamer && pageUser?.name == loggedUser.name"
         [isInPreExpansionSeason]="isInPreExpansionSeason && context.activeExpansion == CURRENT_EXPANSION"
-        (imageClick)="showModal($event)"
+        [reviewersToCompare]="reviewersContext.reviewers"
+        (changedCard)="changeCard($event)"
         (changedRate)="onChangedRate($event)"
         (recordChat)="onRecordChat($event)"
         (stopRecording)="onStopRecording($event)"
-      ></app-card-grid-item>
-    </ng-template>
-  </p-dataView>
-
-  <div *ngIf="shouldShowModal && modalCard">
-    <app-card-view-modal
-      [card]="modalCard"
-      [(shouldShowModal)]="shouldShowModal"
-      [userImg]="pageUser?.image ?? ''"
-      [isLoggedUser]="pageUser?.name == loggedUser?.name"
-      [isUserStreamer]="!!pageUser?.isStreamer"
-      [streamerView]="!!loggedUser && loggedUser.isStreamer && pageUser?.name == loggedUser.name"
-      [isInPreExpansionSeason]="isInPreExpansionSeason && context.activeExpansion == CURRENT_EXPANSION"
-      (changedCard)="changeCard($event)"
-      (changedRate)="onChangedRate($event)"
-      (recordChat)="onRecordChat($event)"
-      (stopRecording)="onStopRecording($event)"
-    >
-    </app-card-view-modal>
-  </div>
+      >
+      </app-card-view-modal>
+    </div>
+  </ng-container>
 </ng-container>

--- a/client/src/app/card-view/feature/card-view/card-view.page.ts
+++ b/client/src/app/card-view/feature/card-view/card-view.page.ts
@@ -1,6 +1,6 @@
-import { AsyncPipe, NgClass, NgIf } from '@angular/common';
+import { AsyncPipe, JsonPipe, NgClass, NgIf } from '@angular/common';
 import { Component } from '@angular/core';
-import { ActivatedRoute, RouterLink } from '@angular/router';
+import { ActivatedRoute, Params, Router, RouterLink } from '@angular/router';
 import { SharedModule } from 'primeng/api';
 import { ButtonModule } from 'primeng/button';
 import { DataViewModule } from 'primeng/dataview';
@@ -18,6 +18,15 @@ import {
   ExpansionService,
 } from '@shared/data-access/expansion/expansion.service';
 import { RATED_CARDS_MOCK } from '@card-view/feature/card-view/card-view-data.mock';
+import {
+  AutoCompleteCompleteEvent,
+  AutoCompleteModule,
+} from 'primeng/autocomplete';
+import {
+  FormBuilder,
+  FormGroup,
+  ReactiveFormsModule,
+} from '@angular/forms';
 
 @Component({
   selector: 'app-card-view',
@@ -34,6 +43,9 @@ import { RATED_CARDS_MOCK } from '@card-view/feature/card-view/card-view-data.mo
     NgClass,
     RouterLink,
     AsyncPipe,
+    AutoCompleteModule,
+    ReactiveFormsModule,
+    JsonPipe,
   ],
 })
 export class CardViewPage {
@@ -50,13 +62,7 @@ export class CardViewPage {
 
   loggedUser$ = this.userService.loggedUser;
 
-  loadingCards$ = this.service.loading.pipe(
-    tap((loading) => {
-      if (loading) {
-        this.cards = RATED_CARDS_MOCK;
-      }
-    })
-  );
+  loadingCards$ = this.service.loading.pipe();
 
   get name() {
     const username = this.pageUser?.name;
@@ -70,18 +76,50 @@ export class CardViewPage {
 
   isInPreExpansionSeason: boolean = false;
 
+  options = this.userService.users.pipe();
+  suggestions: string[] = [];
+  compareReviewsForm: FormGroup = this.fb.group({
+    reviewers: [],
+  });
+
+  compareReviewersFormChanges$ = this.compareReviewsForm.controls[
+    'reviewers'
+  ].valueChanges.pipe(
+    tap((reviewers) =>
+      this.router.navigate([], {
+        relativeTo: this.route,
+        queryParams: { compareTo: reviewers },
+        queryParamsHandling: 'merge',
+      })
+    ),
+  );
+
+  reviewersToCompare$ = this.route.queryParams.pipe(
+    tap((params: Params) => {
+      this.compareReviewsForm.patchValue({reviewers: params['compareTo']}, {emitEvent: false})
+    }),
+    switchMap((params: Params) => {
+      const reviewers = params['compareTo'];
+      return this.service.getCompareReviewersCards(reviewers);
+    })
+  );
+
   constructor(
     private service: CardService,
     private userService: UserService,
     private route: ActivatedRoute,
+    private router: Router,
     private ratingService: RatingService,
     private environment: EnvironmentService,
-    private expansionService: ExpansionService
+    private expansionService: ExpansionService,
+    private fb: FormBuilder
   ) {}
 
   ngOnInit() {
     this.isInPreExpansionSeason = this.environment.isInPreExpansionSeason();
     this.cards = RATED_CARDS_MOCK;
+
+    this.compareReviewersFormChanges$.subscribe();
 
     this.route.params
       .pipe(
@@ -109,6 +147,15 @@ export class CardViewPage {
       },
       error: (_) => (this.loggedUser = null),
     });
+
+  }
+
+  searchUser(event: AutoCompleteCompleteEvent, users: User[]) {
+    this.suggestions = users
+      .filter((user) =>
+        user.name.toLowerCase().includes(event.query.toLowerCase())
+      )
+      .map((u) => u.name);
   }
 
   showModal(card: RatedCard) {

--- a/client/src/app/card-view/feature/card-view/card-view.page.ts
+++ b/client/src/app/card-view/feature/card-view/card-view.page.ts
@@ -96,7 +96,11 @@ export class CardViewPage {
 
   reviewersToCompare$ = this.route.queryParams.pipe(
     tap((params: Params) => {
-      this.compareReviewsForm.patchValue({reviewers: params['compareTo']}, {emitEvent: false})
+      let reviewers = params['compareTo'];
+      if (typeof reviewers === 'string') {
+        reviewers = [reviewers];
+      }
+      this.compareReviewsForm.patchValue({reviewers: reviewers}, {emitEvent: false})
     }),
     switchMap((params: Params) => {
       const reviewers = params['compareTo'];

--- a/client/src/app/card-view/ui/card-grid-item/card-grid-item.component.html
+++ b/client/src/app/card-view/ui/card-grid-item/card-grid-item.component.html
@@ -35,6 +35,27 @@
           ></p-rating>
           <span class="ml-2 w-1rem"></span>
         </div>
+        <ng-container *ngIf="reviewersToCompare.length > 0">
+          <div class="flex" *ngFor="let reviewToCompare of reviewersToCompare; index as i">
+            <a
+              [href]="'https://twitch.tv/' + reviewToCompare[i].user.name"
+              target="_blank"
+            >
+              <p-avatar
+                [image]="reviewToCompare[i].user.image"
+                styleClass="mr-2 avatar cursor-pointer"
+                shape="circle"
+              ></p-avatar>
+            </a>
+            <p-rating
+              [formControlName]="reviewToCompare[i].user.name"
+              [stars]="4"
+              [cancel]="false"
+              [readonly]="true"
+            ></p-rating>
+            <span class="ml-2 w-1rem"></span>
+          </div>
+        </ng-container>
         <div class="flex" *ngIf="card.hsr_rating">
           <a
             [href]="'https://hsreplay.net/cards/' + card.dbf_id"

--- a/client/src/app/card-view/ui/card-view-modal/card-view-modal.component.html
+++ b/client/src/app/card-view/ui/card-view-modal/card-view-modal.component.html
@@ -34,6 +34,27 @@
             ></p-rating>
             <span class="ml-2 w-1rem"></span>
           </div>
+          <ng-container *ngIf="reviewersToCompare.length > 0">
+            <div class="flex" *ngFor="let reviewToCompare of reviewersToCompare; index as i">
+              <a
+                [href]="'https://twitch.tv/' + reviewToCompare[i].user.name"
+                target="_blank"
+              >
+                <p-avatar
+                  [image]="reviewToCompare[i].user.image"
+                  styleClass="mr-2 avatar cursor-pointer"
+                  shape="circle"
+                ></p-avatar>
+              </a>
+              <p-rating
+                [formControlName]="reviewToCompare[i].user.name"
+                [stars]="4"
+                [cancel]="false"
+                [readonly]="true"
+              ></p-rating>
+              <span class="ml-2 w-1rem"></span>
+            </div>
+          </ng-container>
           <div class="flex" *ngIf="card.hsr_rating">
             <a
               [href]="'https://hsreplay.net/cards/' + card.dbf_id"

--- a/client/src/app/shared/data-access/expansion/expansion.service.ts
+++ b/client/src/app/shared/data-access/expansion/expansion.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import { BehaviorSubject, Observable, filter } from 'rxjs';
+import { BehaviorSubject, Observable, distinctUntilChanged, filter, map, pluck } from 'rxjs';
 
 export const CURRENT_EXPANSION = 'Whizbang\'s Workshop';
 
@@ -21,9 +21,11 @@ export class ExpansionService {
   constructor(private route: ActivatedRoute, private router: Router) {
     // reducers
     this.route.queryParams.pipe(
-      filter(params => params['expansion'])
-    ).subscribe(params => {
-      this.state.next(params['expansion']);
+      map(params => params['expansion']), // Extract 'expansion' query parameter
+      distinctUntilChanged(), // Ensure the value changes before triggering the next action
+      filter(expansion => !!expansion) // Filter out falsy values (optional)
+    ).subscribe(expansion => {
+      this.state.next(expansion);
     });
   }
 

--- a/client/src/app/shared/models/hs-card.ts
+++ b/client/src/app/shared/models/hs-card.ts
@@ -58,6 +58,13 @@ export interface RatedCardAPIReturn {
     chatRating?: number;
 }
 
+export interface CompareCardAPIReturn extends RatedCardAPIReturn {
+    user: {
+        name: string;
+        image: string;
+    }
+}
+
 export interface HotCards {
     name: string;
     description: string;


### PR DESCRIPTION
## Summary

Resolves #8 

Added to the query params in the URL for the reviewers the user wants to compareTo.

Also makes the bot only read messages with 1 character.
<!-- Please provide an overview of the work that was completed and the changes this PR introduces. Use the sections below as a guide to provide additional information. -->

**Important**: it introduced a tech debt for when the selected expansion changes with multiple reviewers, but it was merged due to the importance of the feature before the expansion. The tech debt was mapped on the issue #52

## Screenshots/Video

![mulitple-reviews](https://github.com/mateuscechetto/hearthstone-set-review-bot/assets/32515099/feb32760-baf9-454e-aa5d-368c8878ed8d)

<!-- If you're making UX changes, please provide screenshots. For UX bug fixes, make sure to provide before and after screenshots for comparison. For more complex changes, consider recording a video. -->


## Checklist

<!-- Check each of the following boxes to assert that you've completed each task prior to publishing the PR. -->

#### Basics

- [x] Does `npm run build` succeed?
- [] Does `npm run test` succeed?
