### PR TITLE
Fix multiple reviewers not working on expansion change

### DIFF
--- a/client/src/app/card-view/feature/card-view/card-view.page.html
+++ b/client/src/app/card-view/feature/card-view/card-view.page.html
@@ -44,7 +44,7 @@
     </ng-template>
   </div>
 
-  <div *ngIf="options | async as users">
+  <div *ngIf="compareReviewOptions | async as users">
     <form
       [formGroup]="compareReviewsForm"
       class="flex align-items-center ml-2 md:ml-7 gap-2"

--- a/client/src/app/card-view/feature/card-view/card-view.page.spec.ts
+++ b/client/src/app/card-view/feature/card-view/card-view.page.spec.ts
@@ -23,6 +23,7 @@ const userServiceMock = {
   getUser: jest.fn(() => of({ name: 'molino_hs', image: '', isStreamer: true })),
   userIsStreamer: jest.fn(() => of(true)),
   loggedUser: of({ name: 'molino_hs', image: '',  isStreamer: true }),
+  users: of([]),
 }
 
 const ratingServiceMock = {}

--- a/client/src/app/card-view/feature/card-view/card-view.page.ts
+++ b/client/src/app/card-view/feature/card-view/card-view.page.ts
@@ -68,7 +68,7 @@ export class CardViewPage {
 
   isInPreExpansionSeason: boolean = false;
 
-  options = this.userService.users.pipe();
+  compareReviewOptions = this.userService.users.pipe();
   suggestions: string[] = [];
   compareReviewsForm: FormGroup = this.fb.group({
     reviewers: [],

--- a/client/src/app/card-view/ui/card-grid-item/card-grid-item.component.html
+++ b/client/src/app/card-view/ui/card-grid-item/card-grid-item.component.html
@@ -36,19 +36,19 @@
           <span class="ml-2 w-1rem"></span>
         </div>
         <ng-container *ngIf="reviewersToCompare.length > 0">
-          <div class="flex" *ngFor="let reviewToCompare of reviewersToCompare; index as i">
+          <div class="flex" *ngFor="let reviewToCompare of reviewersToCompare;">
             <a
-              [href]="'https://twitch.tv/' + reviewToCompare[i].user.name"
+              [href]="'https://twitch.tv/' + reviewToCompare.user.name"
               target="_blank"
             >
               <p-avatar
-                [image]="reviewToCompare[i].user.image"
+                [image]="reviewToCompare.user.image"
                 styleClass="mr-2 avatar cursor-pointer"
                 shape="circle"
               ></p-avatar>
             </a>
             <p-rating
-              [formControlName]="reviewToCompare[i].user.name"
+              [formControlName]="reviewToCompare.user.name"
               [stars]="4"
               [cancel]="false"
               [readonly]="true"

--- a/client/src/app/card-view/ui/card-grid-item/card-grid-item.component.ts
+++ b/client/src/app/card-view/ui/card-grid-item/card-grid-item.component.ts
@@ -44,7 +44,7 @@ export class CardGridItemComponent implements OnChanges {
   @Input() streamerView: boolean = false;
   @Input() isInPreExpansionSeason: boolean = true;
   @Input() showSkeleton: boolean = false;
-  @Input() reviewersToCompare: CompareCardAPIReturn[][] = [];
+  @Input() reviewersToCompare: CompareCardAPIReturn[] = [];
   @Output() imageClick: EventEmitter<RatedCard> = new EventEmitter<RatedCard>();
   @Output() changedRate: EventEmitter<{ rating: number; card: RatedCard }> =
     new EventEmitter<{ rating: number; card: RatedCard }>();
@@ -77,14 +77,14 @@ export class CardGridItemComponent implements OnChanges {
     }
     if (changes.reviewersToCompare?.currentValue) {
       this.compareRatings = [];
-      this.reviewersToCompare.forEach((review, index) => {
+      this.reviewersToCompare.forEach((review) => {
         //@ts-ignore added because angular 14 added typing to forms and our form is dynamic.
-        if (!this.ratingForm.controls[review[index].user.name]) {
-          const reviewedCard = review.find(c => c.card.dbf_id === this.card.dbf_id);
+        if (!this.ratingForm.controls[review.user.name]) {
+          const reviewedCard = review.cards.find(c => c.card.dbf_id === this.card.dbf_id);
           //@ts-ignore added because angular 14 added typing to forms and our form is dynamic.
-          this.ratingForm.addControl(review[index].user.name, this.fb.control(reviewedCard?.rating || 0));
+          this.ratingForm.addControl(review.user.name, this.fb.control(reviewedCard?.rating || 0));
         }
-        this.compareRatings.push(review[index].user.name);
+        this.compareRatings.push(review.user.name);
       });
     }
   }

--- a/client/src/app/card-view/ui/card-grid-item/card-grid-item.component.ts
+++ b/client/src/app/card-view/ui/card-grid-item/card-grid-item.component.ts
@@ -78,11 +78,14 @@ export class CardGridItemComponent implements OnChanges {
     if (changes.reviewersToCompare?.currentValue) {
       this.compareRatings = [];
       this.reviewersToCompare.forEach((review) => {
+        const reviewedCard = review.cards.find(c => c.card.dbf_id === this.card.dbf_id);
         //@ts-ignore added because angular 14 added typing to forms and our form is dynamic.
         if (!this.ratingForm.controls[review.user.name]) {
-          const reviewedCard = review.cards.find(c => c.card.dbf_id === this.card.dbf_id);
           //@ts-ignore added because angular 14 added typing to forms and our form is dynamic.
           this.ratingForm.addControl(review.user.name, this.fb.control(reviewedCard?.rating || 0));
+        } else {
+          //@ts-ignore added because angular 14 added typing to forms and our form is dynamic.
+          this.ratingForm.patchValue({[review.user.name]: reviewedCard?.rating || 0});
         }
         this.compareRatings.push(review.user.name);
       });

--- a/client/src/app/card-view/ui/card-view-modal/card-view-modal.component.html
+++ b/client/src/app/card-view/ui/card-view-modal/card-view-modal.component.html
@@ -35,19 +35,19 @@
             <span class="ml-2 w-1rem"></span>
           </div>
           <ng-container *ngIf="reviewersToCompare.length > 0">
-            <div class="flex" *ngFor="let reviewToCompare of reviewersToCompare; index as i">
+            <div class="flex" *ngFor="let reviewToCompare of reviewersToCompare">
               <a
-                [href]="'https://twitch.tv/' + reviewToCompare[i].user.name"
+                [href]="'https://twitch.tv/' + reviewToCompare.user.name"
                 target="_blank"
               >
                 <p-avatar
-                  [image]="reviewToCompare[i].user.image"
+                  [image]="reviewToCompare.user.image"
                   styleClass="mr-2 avatar cursor-pointer"
                   shape="circle"
                 ></p-avatar>
               </a>
               <p-rating
-                [formControlName]="reviewToCompare[i].user.name"
+                [formControlName]="reviewToCompare.user.name"
                 [stars]="4"
                 [cancel]="false"
                 [readonly]="true"

--- a/client/src/app/card-view/ui/card-view-modal/card-view-modal.component.ts
+++ b/client/src/app/card-view/ui/card-view-modal/card-view-modal.component.ts
@@ -57,7 +57,7 @@ export class CardViewModalComponent implements OnChanges {
   @Input() isUserStreamer: boolean = false;
   @Input() streamerView: boolean = false;
   @Input() isInPreExpansionSeason: boolean = true;
-  @Input() reviewersToCompare: CompareCardAPIReturn[][] = [];
+  @Input() reviewersToCompare: CompareCardAPIReturn[] = [];
   @Output() changedCard: EventEmitter<number> = new EventEmitter<number>();
   @Output() changedRate: EventEmitter<{ rating: number; card: RatedCard }> =
     new EventEmitter<{ rating: number; card: RatedCard }>();
@@ -103,31 +103,31 @@ export class CardViewModalComponent implements OnChanges {
       this.cardToDisplay = this.card;
 
       this.compareRatings = [];
-      this.reviewersToCompare.forEach((review, index) => {
-        const reviewedCard = review.find(c => c.card.dbf_id === this.cardToDisplay.dbf_id);
+      this.reviewersToCompare.forEach((review) => {
+        const reviewedCard = review.cards.find(c => c.card.dbf_id === this.cardToDisplay.dbf_id);
         //@ts-ignore added because angular 14 added typing to forms and our form is dynamic.
-        if (!this.ratingForm.controls[review[index].user.name]) {
+        if (!this.ratingForm.controls[review.user.name]) {
           //@ts-ignore added because angular 14 added typing to forms and our form is dynamic.
-          this.ratingForm.addControl(review[index].user.name, this.fb.control(reviewedCard?.rating || 0));
+          this.ratingForm.addControl(review.user.name, this.fb.control(reviewedCard?.rating || 0));
         } else {
           //@ts-ignore added because angular 14 added typing to forms and our form is dynamic.
-          this.ratingForm.patchValue({[review[index].user.name]: reviewedCard?.rating || 0});
+          this.ratingForm.patchValue({[review.user.name]: reviewedCard?.rating || 0});
         }
-        this.compareRatings.push(review[index].user.name);
+        this.compareRatings.push(review.user.name);
       });
 
     }
     
     if (changes.reviewersToCompare?.currentValue) {      
       this.compareRatings = [];
-      this.reviewersToCompare.forEach((review, index) => {
+      this.reviewersToCompare.forEach((review) => {
         //@ts-ignore added because angular 14 added typing to forms and our form is dynamic.
-        if (!this.ratingForm.controls[review[index].user.name]) {
-          const reviewedCard = review.find(c => c.card.dbf_id === this.card.dbf_id);
+        if (!this.ratingForm.controls[review.user.name]) {
+          const reviewedCard = review.cards.find(c => c.card.dbf_id === this.card.dbf_id);
           //@ts-ignore added because angular 14 added typing to forms and our form is dynamic.
-          this.ratingForm.addControl(review[index].user.name, this.fb.control(reviewedCard.rating));
+          this.ratingForm.addControl(review.user.name, this.fb.control(reviewedCard.rating));
         }
-        this.compareRatings.push(review[index].user.name);
+        this.compareRatings.push(review.user.name);
       });
     }
   }

--- a/client/src/app/shared/data-access/expansion/expansion.service.ts
+++ b/client/src/app/shared/data-access/expansion/expansion.service.ts
@@ -23,7 +23,7 @@ export class ExpansionService {
     this.route.queryParams.pipe(
       map(params => params['expansion']), // Extract 'expansion' query parameter
       distinctUntilChanged(), // Ensure the value changes before triggering the next action
-      filter(expansion => !!expansion) // Filter out falsy values (optional)
+      filter(expansion => !!expansion) // Filter out falsy values
     ).subscribe(expansion => {
       this.state.next(expansion);
     });

--- a/client/src/app/shared/models/hs-card.ts
+++ b/client/src/app/shared/models/hs-card.ts
@@ -1,77 +1,78 @@
 export enum HearthstonCardType {
-    MINION = "Minion",
-    SPELL = "Spell",
-    WEAPON = "Weapon",
-    HERO = "Hero",
-    LOCATION = "Location",
-    QUEST = "Quest",
+  MINION = 'Minion',
+  SPELL = 'Spell',
+  WEAPON = 'Weapon',
+  HERO = 'Hero',
+  LOCATION = 'Location',
+  QUEST = 'Quest',
 }
 
 export enum HearthstoneClass {
-    DEATH_KNIGHT = "Death Knight",
-    DEMON_HUNTER = "Demon Hunter",
-    DRUID = "Druid",
-    HUNTER = "Hunter",
-    MAGE = "Mage",
-    PALADIN = "Paladin",
-    PRIEST = "Priest",
-    ROGUE = "Rogue",
-    SHAMAN = "Shaman",
-    WARLOCK = "Warlock",
-    WARRIOR = "Warrior",
-    NEUTRAL = "Neutral",
+  DEATH_KNIGHT = 'Death Knight',
+  DEMON_HUNTER = 'Demon Hunter',
+  DRUID = 'Druid',
+  HUNTER = 'Hunter',
+  MAGE = 'Mage',
+  PALADIN = 'Paladin',
+  PRIEST = 'Priest',
+  ROGUE = 'Rogue',
+  SHAMAN = 'Shaman',
+  WARLOCK = 'Warlock',
+  WARRIOR = 'Warrior',
+  NEUTRAL = 'Neutral',
 }
 
 export enum CardRarity {
-    EXTRA = "Extra",
-    BASIC = "Basic",
-    COMMON = "Common",
-    RARE = "Rare",
-    EPIC = "Epic",
-    LEGENDARY = "Legendary",
+  EXTRA = 'Extra',
+  BASIC = 'Basic',
+  COMMON = 'Common',
+  RARE = 'Rare',
+  EPIC = 'Epic',
+  LEGENDARY = 'Legendary',
 }
 
 export interface HearthstoneCard {
-    name: string;
-    description: string;
-    imageURL: string;
-    expansion: string;
-    mana: number;
-    type: HearthstonCardType;
-    hsClass: HearthstoneClass;
-    rarity: CardRarity;
-    atk?: number;
-    health?: number;
-    extraCards?: HearthstoneCard[];
-    hsr_rating?: number;
-    dbf_id?: number;
+  name: string;
+  description: string;
+  imageURL: string;
+  expansion: string;
+  mana: number;
+  type: HearthstonCardType;
+  hsClass: HearthstoneClass;
+  rarity: CardRarity;
+  atk?: number;
+  health?: number;
+  extraCards?: HearthstoneCard[];
+  hsr_rating?: number;
+  dbf_id?: number;
 }
 
 export interface RatedCard extends HearthstoneCard {
-    rating: number;
-    chatRating?: number;
+  rating: number;
+  chatRating?: number;
 }
 
 export interface RatedCardAPIReturn {
-    card: HearthstoneCard;
-    rating: number;
-    chatRating?: number;
+  card: HearthstoneCard;
+  rating: number;
+  chatRating?: number;
 }
 
-export interface CompareCardAPIReturn extends RatedCardAPIReturn {
-    user: {
-        name: string;
-        image: string;
-    }
+export interface CompareCardAPIReturn {
+  user: {
+    name: string;
+    image: string;
+  };
+  cards: RatedCardAPIReturn[];
 }
 
 export interface HotCards {
-    name: string;
-    description: string;
-    hsClass: HearthstoneClass;
-    imageURL: string;
-    avgRating: number;
-    standardDeviation: number;
-    ratings: number[];
-    hsr_rating?: number;
+  name: string;
+  description: string;
+  hsClass: HearthstoneClass;
+  imageURL: string;
+  avgRating: number;
+  standardDeviation: number;
+  ratings: number[];
+  hsr_rating?: number;
 }


### PR DESCRIPTION
## Summary

Resolves #52 

- Improves the backend API return for a better data structure, moving the user to outside the card, so it returns an object with the user and an array of cards instead of an array of cards + user object.
from: 
```
{ 
    ...card,
    user: {
        name,
        image
    }
}[]
```
to:
```
{
    user: {
        name,
        image
    },
    cards: card[]
}
```
This change is specially good because it is possible to find the user even if they didn't rate a card for the requested expansion, and also removes duplicated data.

- Adds the expansion name to the cache key and moves the cache logic into the activeExpansion pipe

<!-- Please provide an overview of the work that was completed and the changes this PR introduces. Use the sections below as a guide to provide additional information. -->

## Screenshots/Video

![multiple-reviews-fix](https://github.com/mateuscechetto/hearthstone-set-review-bot/assets/32515099/ccb17b36-7391-4e7a-8a85-48262c130952)

<!-- If you're making UX changes, please provide screenshots. For UX bug fixes, make sure to provide before and after screenshots for comparison. For more complex changes, consider recording a video. -->

## Testing

<!-- Please provide instructions for how to test the PR that your reviewers can use! -->

- Are there special case scenarios?
- Are there configuration settings that need to be enabled locally?
- Are there error cases to look out for?

## Checklist

<!-- Check each of the following boxes to assert that you've completed each task prior to publishing the PR. -->

#### Basics

- [x] Does `npm run build` succeed?
- [x] Does `npm run test` succeed?

#### Testing

- [x] Did you create new tests and/or update existing tests?
- [x] Did you validate that your changes work hosted locally?
