### PR TITLE
Added search bar to reviewers

### DIFF
--- a/client/src/app/home/feature/home/home.page.html
+++ b/client/src/app/home/feature/home/home.page.html
@@ -1,7 +1,7 @@
 <h1
   class="col-12 flex-order-1 md:flex-order-0 md:col-6 md:col-offset-3 text-center"
 >
-{{ activeExpansion | async }} Card Review
+  {{ activeExpansion | async }} Card Review
 </h1>
 
 <div class="grid md:ml-1">
@@ -164,10 +164,10 @@
   <div class="col-12 hidden flex-order-0 lg:flex-order-1 lg:flex banner">
     <h2>See who reviewed the cards</h2>
   </div>
-  <div class="col-12 flex-order-1 lg:flex-order-2">
+  <div class="col-12 flex-order-1 lg:flex-order-2 reviewers-container">
     <ng-container *ngIf="{loadingUsers: loadingUsers | async} as context">
       <p-table
-        *ngIf="filteredUsersWithRating[0]?.totalDeviation"
+        *ngIf="usersWithRating[0]?.totalDeviation"
         [value]="filteredUsersWithRating"
         [rows]="10"
         [paginator]="true"
@@ -230,15 +230,21 @@
         </ng-template>
       </p-table>
       <p-dataView
-        [value]="usersWithRating"
+        [value]="filteredUsersWithRating"
         [layout]="'list'"
         [rows]="10"
         [paginator]="true"
         *ngIf="!usersWithRating[0]?.totalDeviation"
       >
         <ng-template pTemplate="header">
-          <div class="flex flex-column md:flex-row md:justify-content-between">
+          <div class="reviewersHeader">
             Reviewers
+            <input
+              placeholder="Find a Reviewer"
+              [style]="{ width: '80%' }"
+              (input)="filterUsers($event)"
+              class="searchInput"
+            />
           </div>
         </ng-template>
         <ng-template let-user pTemplate="listItem">

--- a/client/src/app/home/feature/home/home.page.html
+++ b/client/src/app/home/feature/home/home.page.html
@@ -167,12 +167,22 @@
   <div class="col-12 flex-order-1 lg:flex-order-2">
     <ng-container *ngIf="{loadingUsers: loadingUsers | async} as context">
       <p-table
-        *ngIf="usersWithRating[0]?.totalDeviation"
-        [value]="usersWithRating"
+        *ngIf="filteredUsersWithRating[0]?.totalDeviation"
+        [value]="filteredUsersWithRating"
         [rows]="10"
         [paginator]="true"
       >
-        <ng-template pTemplate="caption"> Reviewers </ng-template>
+        <ng-template pTemplate="caption">
+          <div class="reviewersHeader">
+            Reviewers
+            <input
+              placeholder="Find a Reviewer"
+              [style]="{ width: '80%' }"
+              (input)="filterUsers($event)"
+              class="searchInput"
+            />
+          </div>
+        </ng-template>
         <ng-template pTemplate="header">
           <tr>
             <th pSortableColumn="name" style="width: 60%">

--- a/client/src/app/home/feature/home/home.page.scss
+++ b/client/src/app/home/feature/home/home.page.scss
@@ -29,6 +29,16 @@
     }
 }
 
+// Remove table layout shift when filtering results
+.reviewers-container ::ng-deep .p-dataview-content {
+    min-height: 480px;
+}
+
+.reviewers-container ::ng-deep .p-datatable-wrapper {
+    min-height: 517px;
+}
+// --------------------------------------------------
+
 .remove-link-appearance {
     color: inherit;
     text-decoration: inherit;

--- a/client/src/app/home/feature/home/home.page.scss
+++ b/client/src/app/home/feature/home/home.page.scss
@@ -1,3 +1,22 @@
+.searchInput {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+    box-sizing: border-box;
+    font-size: 1rem;
+    color: #495057;
+    background: #ffffff;
+    padding: 0.75rem 0.75rem;
+    border: 1px solid #ced4da;
+    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
+    appearance: none;
+    border-radius: 6px;
+}
+
+.reviewersHeader {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
 .listItem {
     border: solid #dee2e6;
     border-width: 0 0 1px 0;

--- a/client/src/app/home/feature/home/home.page.ts
+++ b/client/src/app/home/feature/home/home.page.ts
@@ -47,14 +47,17 @@ export class HomePage {
   worstCards: HotCards[] = [];
   standardDeviationCards: HotCards[] = [];
   usersWithRating: User[] = [];
+  filteredUsersWithRating: User[] = [];
   activeExpansion = this.expansionService.activeExpansion;
+
   loadingUsers = this.homeService.loadingUsers.pipe(
     tap((loading) => {
       if (loading) {
-        this.usersWithRating = USERS_MOCK;
+        this.filteredUsersWithRating = USERS_MOCK;
       }
     })
   );
+
   loadingStats = this.homeService.loadingStats.pipe(
     tap((loading) => {
       if (loading) {
@@ -74,6 +77,7 @@ export class HomePage {
     this.homeService.getUsers().subscribe({
       next: (users) => {
         this.usersWithRating = users.sort(this.sortUsers);
+        this.filteredUsersWithRating = users.sort(this.sortUsers);
       },
     });
 
@@ -85,6 +89,15 @@ export class HomePage {
         this.standardDeviationCards = standardDeviationCards;
       },
     });
+  }
+
+  filterUsers(event: Event) {
+    const searchQuery = (event.target as HTMLInputElement).value.toLowerCase();
+    if (searchQuery === '') {
+      this.filteredUsersWithRating = this.usersWithRating;
+    } else {
+      this.filteredUsersWithRating = this.usersWithRating.filter(user => user.name.toLowerCase().includes(searchQuery));
+    }
   }
 
   private sortUsers(a: User, b: User): number {

--- a/client/src/app/home/feature/home/home.page.ts
+++ b/client/src/app/home/feature/home/home.page.ts
@@ -77,7 +77,7 @@ export class HomePage {
     this.homeService.getUsers().subscribe({
       next: (users) => {
         this.usersWithRating = users.sort(this.sortUsers);
-        this.filteredUsersWithRating = users.sort(this.sortUsers);
+        this.filteredUsersWithRating = this.usersWithRating;
       },
     });
 
@@ -96,7 +96,7 @@ export class HomePage {
     if (searchQuery === '') {
       this.filteredUsersWithRating = this.usersWithRating;
     } else {
-      this.filteredUsersWithRating = this.usersWithRating.filter(user => user.name.toLowerCase().includes(searchQuery));
+      this.filteredUsersWithRating = this.usersWithRating.filter(user => user.name.toLowerCase().includes(searchQuery)) || [];
     }
   }
 


### PR DESCRIPTION
## Summary

This extends the previous work for searching cards to the reviewers on the home page. The system is basically identical, allowing users to search by name and sort using the columns in the table.

## Screenshots/Video


https://github.com/mateuscechetto/hearthstone-set-review-bot/assets/10130985/b5c180e1-a29a-4e7e-b2d8-8cc586d466dd


## Testing

Launch this branch, then go to the home page. The reviewers table at the bottom should now have a search bar where you can query by name. You should be able to sort as normal and click on any of the users to jump to their reviews.

## Checklist

#### Basics

- [x] Does `npm run build` succeed?
- [x] Does `npm run test` succeed?

#### Testing

- [x] Did you create new tests and/or update existing tests?
- [x] Did you validate that your changes work hosted locally?

#### Accessibility (UX)

- [x] Did you check that all colors meet minimum contrast ratios?